### PR TITLE
Remove deprecated function and used new function instead that

### DIFF
--- a/reflect2.php
+++ b/reflect2.php
@@ -37,7 +37,7 @@
 	}
 	
 	//	GD check
-	if (extension_loaded('gd') == false && !dl('gd.so'))
+	if (extension_loaded('gd') == false)
 	{
 		echo 'You are missing the GD extension for PHP, sorry but I cannot continue.';
 		exit();

--- a/reflect3.php
+++ b/reflect3.php
@@ -28,7 +28,7 @@
 	}
 	
 	//	GD check
-	if (extension_loaded('gd') == false && !dl('gd.so'))
+	if (extension_loaded('gd') == false)
 	{
 		echo 'You are missing the GD extension for PHP, sorry but I cannot continue.';
 		exit();
@@ -43,7 +43,7 @@
         exit();
     }
     
-    if (ereg_replace('[[:alpha:][:space:]()]+', '', $gd_info['GD Version']) < '2.0.1')
+    if (preg_replace('[[:alpha:][:space:]()]+', '', $gd_info['GD Version']) < '2.0.1')
     {
         echo 'GD library is too old. Version 2.0.1 or later is required, and 2.0.28 is strongly recommended.';
         exit();


### PR DESCRIPTION
Run Command => $ phpcs --standard=PHPCompatibility --extensions=php,module,inc,install,test,profile,theme --runtime-set testVersion 7.2 ImageFlow/

FILE: D:\git\patch\ImageFlow\reflect2.php =>  WARNING | Function dl() is deprecated since PHP 5.3
FILE: D:\git\patch\ImageFlow\reflect3.php =>
1.  WARNING | Function dl() is deprecated since PHP 5.3
2.  ERROR   | Extension 'ereg' is deprecated since PHP 5.3 and removed since PHP 7.0; Use pcre instead
3.  ERROR   | Function ereg_replace() is deprecated since PHP 5.3 and removed since PHP 7.0; Use reg_replace() instead

1]Removed deprecated function **dl()**;
2]Replace **ereg_replace()** with **preg_replace()**.


